### PR TITLE
Fix unit tests to be 4.5 compatible

### DIFF
--- a/tests/accountsync_test.php
+++ b/tests/accountsync_test.php
@@ -46,7 +46,7 @@ class auth_accountsync_testcase extends advanced_testcase {
     /**
      * Setup test data.
      */
-    protected function setUp() {
+    protected function setUp() : void {
         $this->resetAfterTest(true);
         set_config('accountsync_wstoken', '1x2x3', auth_plugin_accountsync::COMPONENT_NAME);
         set_config('accountsync_wsurl', 'http://testsite.com', auth_plugin_accountsync::COMPONENT_NAME);


### PR DESCRIPTION
Failing unit test in Moodle 4.5

```
Moodle 4.5.5 (Build: 20250609), c18c6d6561eccd088966e965b8a16d6297e522a7
Php: 8.1.32, mysqli: 8.0.42, OS: Linux 6.11.0-26-generic x86_64

Fatal error: Declaration of auth_accountsync_testcase::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /var/www/moodle/auth/accountsync/tests/accountsync_test.php on line 49
```